### PR TITLE
Added fix explaining where AssetType comes from as a very simple example

### DIFF
--- a/yaml/uproperty.yml
+++ b/yaml/uproperty.yml
@@ -1869,17 +1869,28 @@ specifiers:
         UCLASS(Blueprintable, BlueprintType)
         class UFancyNamedDataAsset : public UPrimaryDataAsset
         {
+            GENERATED_BODY()
+        public:
+        
             UFancyNamedDataAsset()
             { 
                 // This is the allowed type, which is the FPrimaryAssetType
                 AssetType = TEXT("FancyAssetName");
-            }              
+            }
+        
+            // UObject interface
+            virtual FPrimaryAssetId GetPrimaryAssetId() const override { return FPrimaryAssetId(AssetType, GetFName()); }
+            // ~UObject interface
+        
+            /** The type of asset, in this example this value HAS to be specified in the constructor for each type(unless its abstract). */
+            UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category= "Primary Asset")
+            FPrimaryAssetType AssetType;
         }
       - |
         UPROPERTY(meta = (AllowedTypes = "FancyAssetName"))
         FPrimaryAssetId FancyAsset;
         
-        // Affects any primary asset ID's in the TMap
+        /** Affects any primary asset ID's in the TMap */
         UPROPERTY(meta = (AllowedTypes = "FancyAssetName"))
         TMap<FGameplayTag, FPrimaryAssetId> FancyAssetMap; 
   - name: AssetRegistrySearchable


### PR DESCRIPTION
Realized that I never gave context for `AssetType` when I wrote the example, apologies!

This change pretty much adds the variable type and the override function using that variable for defining the Asset ID and its Type.