### PR TITLE
Improve docs for ForceAsFunction

### DIFF
--- a/yaml/ufunction.yml
+++ b/yaml/ufunction.yml
@@ -39,7 +39,7 @@ specifiers:
     position: meta
     version: ">= 5.1"
     comment: |
-      Can be applied to BlueprintImplementableEvent or BlueprintNative functions which have no return value to cause 
+      Can be applied to BlueprintImplementableEvent or BlueprintNativeEvent functions which have no return value to cause 
       the editor to create a function instead of an event when using the Override feature of the Blueprint editor. 
       Despite the name, this does not prevent you from using "Convert function to event" after creating the override.
     samples:

--- a/yaml/ufunction.yml
+++ b/yaml/ufunction.yml
@@ -38,8 +38,15 @@ specifiers:
     type: flag
     position: meta
     version: ">= 5.1"
-    comment: Allows users to change a BlueprintImplementableEvent with no return value from an event into a function.
-    required: [ BlueprintImplementableEvent ]
+    comment: |
+      Can be applied to BlueprintImplementableEvent or BlueprintNative functions which have no return value to cause 
+      the editor to create a function instead of an event when using the Override feature of the Blueprint editor. 
+      Despite the name, this does not prevent you from using "Convert function to event" after creating the override.
+    samples:
+    - |
+      UFUNCTION(BlueprintImplementableEvent, meta=(ForceAsFunction))
+      void PreferFunction();
+    required: [ BlueprintImplementableEvent, BlueprintNativeEvent ]
     links:
       - [ "Changelist", "https://github.com/EpicGames/UnrealEngine/commit/8942fcd50bf1cb828ccbb9cfd84ee2619f020fce" ]
 


### PR DESCRIPTION
`ForceAsFunction` doesn't actually *force* the user to use a function- it just hints the Blueprint editor to create a function when using Override. The user can still convert between function/event as they desire. Also clarifies that this works for both `BlueprintImplementableEvent` and `lueprintNativeEvent` and adds a sample.