### PR TITLE
Update uproperty.yml - EditCondition clarification

### DIFF
--- a/yaml/uproperty.yml
+++ b/yaml/uproperty.yml
@@ -366,6 +366,8 @@ specifiers:
       The simplest way is simply using another `bool` property, but as of 4.23 more complex statements are supported.
 
       It is worth noting that `EditCondition` also changes the appearance of properties inside Blueprint logic Make Struct nodes.
+
+      Note that any variable used in the `EditCondition` needs to also be a `UPROPERTY`. 
     position: meta
     samples: 
     - |


### PR DESCRIPTION
Any variable used in an EditCondition needs to also be a UPROPERTY, otherwise it won't work.

Checked on 5.4.4, I'm told the behavior is the same on 5.5.